### PR TITLE
Cards for markets (tile view for mobile?)

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,12 +1,15 @@
 import React, { Component } from 'react';
 import Navbar from './navbar'
 import Card from './card'
+import { getMarketDetails } from '../services/get-market-details'
 
 export default class App extends Component {
   constructor(props) {
     super(props)
 
     this.state = {markets: [], marketDetails: []}
+    this.updateMarketDetails = this.updateMarketDetails.bind(this)
+    this.updateMarkets = this.updateMarkets.bind(this)
   }
 
   componentDidMount() {
@@ -15,33 +18,31 @@ export default class App extends Component {
 
     const self = this;
 
-    const getDetail = (id) => {
-      $.ajax({
-        type: 'GET',
-        contentType: 'application/json; charset=utf-8',
-        url: 'http://search.ams.usda.gov/farmersmarkets/v1/data.svc/mktDetail?id=' + id,
-        dataType: 'jsonp',
-        success: data => {
-          self.setState({marketDetails: self.state.marketDetails.concat(data)})
-        }
-      })
-    }
     $.ajax({
       type: "GET",
       contentType: "application/json; charset=utf-8",
       url: `${baseURL}/zipSearch?zip=${zip}`,
       dataType: 'jsonp',
       success: (data) => {
-        this.setState({markets: data.results})
-        console.log(this.state)
+        this.updateMarkets(data.results)
+
         const ids = this.state.markets.map(market => market.id)
         ids.forEach(id => {
-          getDetail(id)
+          getMarketDetails(id, this.updateMarketDetails)
         })
       },
       fail: err => console.log(err)
     });
 
+  }
+
+  updateMarketDetails(data) {
+    const { marketDetails } = this.state
+    this.setState({marketDetails: marketDetails.concat(data)})
+  }
+
+  updateMarkets(data) {
+    this.setState({markets: this.state.markets.concat(data)})
   }
 
   render() {
@@ -55,11 +56,11 @@ export default class App extends Component {
             Schedule
           } = market.marketdetails
 
-          console.log(market)
           return (
             <Card 
               title={market.marketdetails.Address} textItems={[]} 
               textItems={[Address, GoogleLink, Products, Schedule]}
+              key={GoogleLink}
             />
           )
         })

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Navbar from './navbar'
+import Card from './card'
 
 export default class App extends Component {
   constructor(props) {
@@ -13,6 +14,18 @@ export default class App extends Component {
     const zip = '67208';
 
     const self = this;
+
+    const getDetail = (id) => {
+      $.ajax({
+        type: 'GET',
+        contentType: 'application/json; charset=utf-8',
+        url: 'http://search.ams.usda.gov/farmersmarkets/v1/data.svc/mktDetail?id=' + id,
+        dataType: 'jsonp',
+        success: data => {
+          self.setState({marketDetails: self.state.marketDetails.concat(data)})
+        }
+      })
+    }
     $.ajax({
       type: "GET",
       contentType: "application/json; charset=utf-8",
@@ -23,35 +36,31 @@ export default class App extends Component {
         console.log(this.state)
         const ids = this.state.markets.map(market => market.id)
         ids.forEach(id => {
-
-        $.ajax({
-          type: 'GET',
-          contentType: 'application/json; charset=utf-8',
-          url: 'http://search.ams.usda.gov/farmersmarkets/v1/data.svc/mktDetail?id=' + id,
-          dataType: 'jsonp',
-          success: data => self.setState({marketDetails: self.state.marketDetails.concat(data)})
-        })
-
+          getDetail(id)
         })
       },
       fail: err => console.log(err)
     });
+
   }
 
   render() {
     const details = () => {
       if(this.state.marketDetails.length) {
         return this.state.marketDetails.map(market => {
+          const {
+            Address, 
+            GoogleLink, 
+            Products, 
+            Schedule
+          } = market.marketdetails
+
           console.log(market)
           return (
-            <div className='card'>
-              <div className='card-block'>
-                <h4 className='card-title'>{market.marketdetails.Address}</h4>
-                <p className='card-text'>{market.marketdetails.GoogleLink}</p>
-                <p className='card-text'>{market.marketdetails.Products}</p>
-                <p className='card-text'>{market.marketdetails.Schedule}</p>
-              </div>
-            </div>
+            <Card 
+              title={market.marketdetails.Address} textItems={[]} 
+              textItems={[Address, GoogleLink, Products, Schedule]}
+            />
           )
         })
       }

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -5,30 +5,63 @@ export default class App extends Component {
   constructor(props) {
     super(props)
 
-    this.state = {markets: []}
+    this.state = {markets: [], marketDetails: []}
   }
 
   componentDidMount() {
     const baseURL = 'http://search.ams.usda.gov/farmersmarkets/v1/data.svc/'
     const zip = '67208';
 
+    const self = this;
     $.ajax({
       type: "GET",
       contentType: "application/json; charset=utf-8",
       url: `${baseURL}/zipSearch?zip=${zip}`,
       dataType: 'jsonp',
-      success: (data) => this.setState({markets: data.results}),
+      success: (data) => {
+        this.setState({markets: data.results})
+        console.log(this.state)
+        const ids = this.state.markets.map(market => market.id)
+        ids.forEach(id => {
+
+        $.ajax({
+          type: 'GET',
+          contentType: 'application/json; charset=utf-8',
+          url: 'http://search.ams.usda.gov/farmersmarkets/v1/data.svc/mktDetail?id=' + id,
+          dataType: 'jsonp',
+          success: data => self.setState({marketDetails: self.state.marketDetails.concat(data)})
+        })
+
+        })
+      },
       fail: err => console.log(err)
     });
   }
 
   render() {
+    const details = () => {
+      if(this.state.marketDetails.length) {
+        return this.state.marketDetails.map(market => {
+          console.log(market)
+          return (
+            <div className='card'>
+              <div className='card-block'>
+                <h4 className='card-title'>{market.marketdetails.Address}</h4>
+                <p className='card-text'>{market.marketdetails.GoogleLink}</p>
+                <p className='card-text'>{market.marketdetails.Products}</p>
+                <p className='card-text'>{market.marketdetails.Schedule}</p>
+              </div>
+            </div>
+          )
+        })
+      }
+
+      return <p>No Details</p>
+    }
     return (
       <div className='row'>
         <Navbar links={['Sign In', 'Contact']} />
-        {this.state.markets.map(market => {
-          return <p key={market.id}>{market.marketname}</p>
-        })}
+        {details()}
       </div>
     );
   }

--- a/src/components/card.js
+++ b/src/components/card.js
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const Card = (props) => (
+  <div className='card'>
+    <div className='card-block'>
+      <h4 className='card-title'>{props.title}</h4>
+      {props.textItems.map(item => <p className='card-text'>{item}</p>)}
+    </div>
+  </div>
+)
+
+export default Card

--- a/src/components/card.js
+++ b/src/components/card.js
@@ -4,7 +4,9 @@ const Card = (props) => (
   <div className='card'>
     <div className='card-block'>
       <h4 className='card-title'>{props.title}</h4>
-      {props.textItems.map(item => <p className='card-text'>{item}</p>)}
+      {props.textItems.map(item => (
+        <p key={Math.random()} className='card-text'>{item}</p>
+      ))}
     </div>
   </div>
 )

--- a/src/services/get-market-details.js
+++ b/src/services/get-market-details.js
@@ -1,0 +1,13 @@
+export const getMarketDetails = (id, cb) => {
+  $.ajax({
+    type: 'GET',
+    contentType: 'application/json; charset=utf-8',
+    url: 'http://search.ams.usda.gov/farmersmarkets/v1/data.svc/mktDetail?id=' + id,
+    dataType: 'jsonp',
+    success: data => {
+      cb(data)
+      // self.setState({marketDetails: self.state.marketDetails.concat(data)})
+    }
+  })
+}
+

--- a/test/components/card_test.js
+++ b/test/components/card_test.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow, mount } from 'enzyme'
+import Card from '../../src/components/card'
+
+describe('Card', () => {
+  it('should render a div with the card class', () => {
+    const card = shallow(<Card textItems={['item']}/>)
+
+    expect(card.find('div.card').length).to.eql(1)
+  })
+
+  it('should render the title', () => {
+    const card = shallow(<Card textItems={['items']} title={'Title'}/>)
+
+    expect(card.contains(<h4 className='card-title'>Title</h4>)).to.eql(true)
+  })
+
+  it('should render the card text items', () => {
+    const card = shallow(<Card textItems={['Item 1', 'Item 2']} title={'Title'}/>)
+
+    expect(card.contains(<p className='card-text'>Item 1</p>)).to.eql(true)
+    expect(card.contains(<p className='card-text'>Item 2</p>)).to.eql(true)
+  })
+})

--- a/test/components/navbar_test.js
+++ b/test/components/navbar_test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import { shallow } from 'enzyme'
 import Navbar from '../../src/components/navbar'
 
-describe('App' , () => {
+describe('Navbar' , () => {
   it('should render the Navbar with the appropriate number of links', () => {
     const navbar = shallow(<Navbar links={['Sign in', 'About']} />)
     expect(navbar.find('nav ul.nav li').length).to.eql(2)

--- a/test/components/navbar_test.js
+++ b/test/components/navbar_test.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import Navbar from '../../src/components/navbar'
+
+describe('App' , () => {
+  it('should render the Navbar with the appropriate number of links', () => {
+    const navbar = shallow(<Navbar links={['Sign in', 'About']} />)
+    expect(navbar.find('nav ul.nav li').length).to.eql(2)
+  });
+
+  it('should render the links as text', () => {
+    const navbar = shallow(<Navbar links={['Sign in', 'About']} />)
+    const signIn = <a className='nav-link' href='#'>Sign in</a>
+    const about = <a className='nav-link' href='#'>About</a>
+
+    expect(navbar.contains(signIn)).to.eql(true)
+    expect(navbar.contains(about)).to.eql(true)
+  })
+});


### PR DESCRIPTION
Need to normalize data somehow since we have to fetch all markets in a location and THEN fetch the markets individual details by their ids. Right now the markets name and id are in a separate piece of state than each markets details. Also, none of this is wired up to redux quite yet. Just getting it all working first, but any input/feedback would be great. @prestontallen 

Also, we should probably just start the mobile width with the tile layout like on Rezi or whichever app that was.
